### PR TITLE
Set up containerized CI for integration testing branch deploy cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run tests
-        run: docker run -i -w/app/branch-deploy rick/branch-deploy-acceptance:latest bundle exec rake
+        run: docker run -i -w/app/branch-deploy rick/branch-deploy-acceptance bundle exec rake
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           context: .
+          load: true
           file: ./spec/Dockerfile
           tags: rick/branch-deploy-acceptance:latest
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: Ruby
 
 on:
@@ -18,15 +11,21 @@ permissions:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby-version: ['3.2.2', '2.7.8']
 
     steps:
-    - uses: actions/checkout@v4
-    - name: build acceptance test docker image
-      run: docker build -t branch-deploy-acceptance -f ./spec/Dockerfile .
-    - name: Run tests
-      run: docker run -i -w/app/branch-deploy branch-deploy-acceptance bundle exec rake
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./spec/Dockerfile
+          tags: rick/branch-deploy-acceptance:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run tests
+        run: docker run -i -w/app/branch-deploy rick/branch-deploy-acceptance:latest bundle exec rake
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
       - uses: docker/build-push-action@v5
         with:
           context: .
@@ -22,7 +24,6 @@ jobs:
           tags: rick/branch-deploy-acceptance:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
   test:
     depends-on: build-with-docker
     runs-on: rick/branch-deploy-acceptance:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
           file: ./spec/Dockerfile
           tags: rick/branch-deploy-acceptance:latest
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@5cfe23c062c0aac352e765b1b7cc12ea5255ccc4
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: build acceptance test docker image
+      run: docker build -t branch-deploy-acceptance < ./spec/Dockerfile
     - name: Run tests
-      run: bundle exec rake
-
+      run: docker run -it -w/app/branch-deploy bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
     - name: build acceptance test docker image
       run: docker build -t branch-deploy-acceptance -f ./spec/Dockerfile .
     - name: Run tests
-      run: docker run -i -w/app/branch-deploy bundle exec rake
+      run: docker run -i -w/app/branch-deploy branch-deploy-acceptance bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,6 @@ jobs:
           tags: rick/branch-deploy-acceptance:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-  test:
-    depends-on: build-with-docker
-    runs-on: rick/branch-deploy-acceptance:latest
-    steps:
       - name: Run tests
-        run: bundle exec rake
+        run: docker run -e -w/app/branch-deploy rick/branch-deploy-acceptance:latest bundle exec rake
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: build acceptance test docker image
-      run: docker build -t branch-deploy-acceptance < ./spec/Dockerfile
+      run: docker build -t branch-deploy-acceptance -f ./spec/Dockerfile .
     - name: Run tests
       run: docker run -it -w/app/branch-deploy bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  build-with-docker:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby-version: ['3.2.2', '2.7.8']
-
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -26,6 +22,11 @@ jobs:
           tags: rick/branch-deploy-acceptance:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  test:
+    depends-on: build-with-docker
+    runs-on: rick/branch-deploy-acceptance:latest
+    steps:
       - name: Run tests
-        run: docker run -i -w/app/branch-deploy rick/branch-deploy-acceptance bundle exec rake
+        run: bundle exec rake
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
     - name: build acceptance test docker image
       run: docker build -t branch-deploy-acceptance -f ./spec/Dockerfile .
     - name: Run tests
-      run: docker run -it -w/app/branch-deploy bundle exec rake
+      run: docker run -i -w/app/branch-deploy bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker
       - uses: docker/build-push-action@v5
         with:
           context: .
+          push: true
           file: ./spec/Dockerfile
           tags: rick/branch-deploy-acceptance:latest
           cache-from: type=gha

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -14,9 +14,6 @@ OptionParser.new do |opts|
   opts.on('-h', '--host HOSTNAME', 'Target host for remote deployment [REQUIRED, or --local]') do |h|
     options[:host] = h
   end
-  opts.on('-l', '--local', 'Deploy to the local host (default: false) [REQUIRED, or --host]') do |l|
-    options[:local] = l
-  end
   opts.on('-p', '--path PATH', 'Deployment path on target host [REQUIRED]') do |p|
     options[:path] = p
   end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -14,6 +14,9 @@ OptionParser.new do |opts|
   opts.on('-h', '--host HOSTNAME', 'Target host for remote deployment [REQUIRED, or --local]') do |h|
     options[:host] = h
   end
+  opts.on('-l', '--local', 'Deploy to the local host (default: false) [REQUIRED, or --host]') do |l|
+    options[:local] = l
+  end
   opts.on('-p', '--path PATH', 'Deployment path on target host [REQUIRED]') do |p|
     options[:path] = p
   end

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -25,7 +25,7 @@ if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
   }
 fi
 
-if [ ! -e "${ROOT_DIR}/.git/hooks/pre-commit" ]; then
+if [ ! -L "${ROOT_DIR}/.git/hooks/pre-commit" ]; then
     echo "Creating pre-commit hook in .git/hooks/"
     ln -s "${ROOT_DIR}/hooks/pre-commit" "${ROOT_DIR}/.git/hooks/pre-commit"
 fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/bootstrap: Resolve all dependencies that the application requires to run.
 #
@@ -16,18 +16,22 @@ if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
   }
 fi
 
-if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
-  echo "==> Installing Ruby…"
-  rbenv install --skip-existing
-  command -v bundle >/dev/null 2>&1  || {
-    gem install bundler
-    rbenv rehash
-  }
+if command -v rbenv &> /dev/null; then
+  if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+    echo "==> Installing Ruby…"
+    rbenv install --skip-existing
+    command -v bundle >/dev/null 2>&1  || {
+      gem install bundler
+      rbenv rehash
+    }
+  fi
 fi
 
 if [ ! -L "${ROOT_DIR}/.git/hooks/pre-commit" ]; then
+  if [ -f "${ROOT_DIR}/.git/hooks/pre-commit" ]; then
     echo "Creating pre-commit hook in .git/hooks/"
     ln -s "${ROOT_DIR}/hooks/pre-commit" "${ROOT_DIR}/.git/hooks/pre-commit"
+  fi
 fi
 
 if [ -f "Gemfile" ]; then

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # script/test: run the test suite
 
@@ -7,10 +7,34 @@ set -e
 ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && cd .. && pwd )
 cd "$ROOT_DIR"
 
-# when no arguments passed
+cleanup() {
+  trap - EXIT
+
+  if [ -n "$CONTAINER_NEEDS_SHUTDOWN" ]; then
+    docker stop ${CONTAINER} >/dev/null
+  fi
+  unset CONTAINER_NEEDS_SHUTDOWN
+}
+trap cleanup EXIT
+
+# make sure our acceptance test container is built and running
+docker build -t branch-deploy-acceptance -f ${ROOT_DIR}/spec/Dockerfile .
+CONTAINER=$(docker run --detach -h branchdeploy --rm -it -p 8822:22 branch-deploy-acceptance)
+
+export CONTAINER_NEEDS_SHUTDOWN="true"
+
 if [ $# -eq 0 ]; then
-  # run all tests
-  bundle exec rake spec
+  # when no arguments passed, run all tests
+  command="cd /app/branch-deploy && bundle exec rake"
 else
-  bundle exec ruby -Ilib:spec "$@"
+  # when arguments passed, run only those tests specified
+  command="cd /app/branch-deploy && bundle exec ruby -Ilib:spec $@"
 fi
+
+docker exec ${CONTAINER} sh -c "${command}" && exitcode=$? || exitcode=$?
+
+# shut down the container
+cleanup
+
+# return the saved exit code from the test run
+exit $exitcode

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -14,13 +14,6 @@ RUN apt-get update && apt-get install -y \
     vim \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
-COPY "./" "/app/branch-deploy/"
-
-WORKDIR /app/branch-deploy
-RUN gem install bundler
-RUN bundle install
-
 # Generate SSH key and copy to authorized keys
 RUN ssh-keygen -q -f /root/.ssh/id_rsa -N ""
 RUN cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
@@ -34,5 +27,15 @@ EOF
 # Set up SSH server
 RUN mkdir -p /run/sshd
 RUN echo 'root:test123' | chpasswd
+
+COPY "Gemfile" "/app/branch-deploy/"
+COPY "Gemfile.lock" "/app/branch-deploy/"
+COPY "script/bootstrap" "/app/branch-deploy/script/"
+
+WORKDIR /app/branch-deploy
+RUN script/bootstrap
+
+COPY "./" "/app/branch-deploy/"
+
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D", "-o", "ListenAddress=0.0.0.0", "-o", "PermitRootLogin=yes", "-o", "PasswordAuthentication=yes"]

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2,7 +2,6 @@
 
 require 'debug'
 require 'minitest/autorun'
-require 'open3'
 require_relative 'spec_helper'
 
 def options_full

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -165,6 +165,13 @@ describe 'CLI usage' do
     _(stderr).must_be_empty
   end
 
+  it 'should work if short local argument is passed instead of host' do
+    long_hash = args_hash(required_option_keys - [:host] + [:local])
+    args = to_short_arg(long_hash, :local)
+    _, _, status = run_bd_command(args_list(args))
+    _(status).must_equal 0
+  end
+
   it 'should exit with status 1 if no host or local is passed' do
     args = args_hash(required_option_keys - [:host] - [:local])
     _, _, status = run_bd_command(args_list(args))

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,20 +5,6 @@ require 'minitest/autorun'
 require 'open3'
 require_relative 'spec_helper'
 
-def bd_command
-  File.expand_path(File.join(__dir__, '../bin/bd'))
-end
-
-def run_bd_command(args = [])
-  if args.empty?
-    stdout, stderr, status = Open3.capture3(bd_command)
-  else
-    stdout, stderr, status = Open3.capture3(bd_command, *args)
-  end
-
-  [stdout, stderr, status.exitstatus]
-end
-
 def options_full
   {
     repo: ['--repo', 'git@github.com:rick/branch-deploy.git'],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 unless Hash.method_defined? :except
   class Hash
     def except(*keys)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,17 @@ unless Hash.method_defined? :except
     end
   end
 end
+
+def bd_command
+  File.expand_path(File.join(__dir__, '../bin/bd'))
+end
+
+def run_bd_command(args = [])
+  if args.empty?
+    stdout, stderr, status = Open3.capture3(bd_command)
+  else
+    stdout, stderr, status = Open3.capture3(bd_command, *args)
+  end
+
+  [stdout, stderr, status.exitstatus]
+end


### PR DESCRIPTION
![death-star-award](https://github.com/rick/branch-deploy/assets/6259/e2abbc03-830d-4106-a2c1-31702bb85f94)


It seems like, with GitHub Actions, we should be able to spin up a target container in CI, have it enable an SSH server, and then run the `bd` command using that host as a target. Given that we can SSH in, we should be able to validate the effects of having run `bd` deployments.

The question of having a repository to clone, getting access to it, etc., for the purposes of integration tests comes up. I think it might just be that cloning from bare git repos inside the container would suffice. 

I seem to recall having a libgit-style test fixture thing back in ~2013 when I worked at GitHub, where one could programmatically express creating a "fixture" git repo. Anyway, if we create "fixture repos" here in, e.g., `spec/fixture_repos`, then we can scp that tree to the container, and set the `--repo` arg to point to the local path in question, and then run the `bd` deploy and verify the results.

I seem to recall that it was a pain having a `.git` in a fixture repo down inside a repo, so there's a case to be made for packaging up fixtures via (say) `tar` for storage, and generating them from a readable fixture language.

### the work

 - [x] cleanup: move `bd_command` helpers to main `spec_helper.rb` file
 - [x] research: can I find the libgit-style git wrapper for readable repo creation?
   - [x] https://github.com/libgit2/rugged
   - [x] easy to "clone" from a bare repo: https://thehorrors.org.uk/snippets/git-local-filesystem-remotes/
 - [x] research: what does it take to set up a container we can ssh into during CI?
   - [x] https://docs.github.com/en/actions/using-containerized-services/about-service-containers?learn=continuous_integration#running-jobs-in-a-container
    - [x] https://dev.to/s1ntaxe770r/how-to-setup-ssh-within-a-docker-container-i5i
 - [x] research: er, what about running local tests prior to pushing to CI?
   - [x] iirc, entitlements did this via `docker-compose`, go back and look at that
 - [x] bugfix: move `open3` require to `spec_helper.rb`, as this was missed earlier
 - [x] add spec for short version of `--local` arg being passed (missed this)
 - [x] create a Dockerfile running sshd to itself
   - [x] convert local tests to run against this docker container
   - [x] convert CI tests to run against this docker container
   - [x] can we cache docker builds?
     - [x] https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
     - [x] https://depot.dev/blog/docker-layer-caching-in-github-actions
     - [x] https://docs.docker.com/build/ci/github-actions/cache/

### later:

 - [ ] get rugged installed
   - [ ] Brewfile probably for system level deps
   - [ ] Gemfile
   - [ ] maybe Gemfile options
 - [ ] Create a single local fixture repo with rugged
 - [ ] tar+gz fixture repo for use as a fixture, but (cached) stored in this repo for easy deployment
 - [ ] get a basic `bd --diff` deploy working
   - [ ] send fixture repos to target container, uncompress
   - [ ] run `bd deploy` with `--repo` being a container-local target for the fixture / scenario
   - [ ] evaluate results
